### PR TITLE
Update with upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.3.0 2022-11-26
+
+* Support the origin detection over UDP from Datadog via DD_ENTITY_ID env var
+
 ## 2.2.0 2022-07-31
 
 * Support communicating with the Datadog agent via a UNIX socket (set STATSD_SOCKET_PATH env var) (PR #[38](https://github.com/yob/puma-plugin-statsd/pull/38))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.4.0 2022-12-27
+
+* Support puma 6 (PR #[46](https://github.com/yob/puma-plugin-statsd/pull/46))
+
 ## 2.3.0 2022-11-26
 
 * Support the origin detection over UDP from Datadog via DD_ENTITY_ID env var

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # CHANGELOG
 
+## 2.2.0 2022-07-31
+
+* Support communicating with the Datadog agent via a UNIX socket (set STATSD_SOCKET_PATH env var) (PR #[38](https://github.com/yob/puma-plugin-statsd/pull/38))
+
 ## 2.1.0 2021-12-04
 
-* Adds support for Datadog unified service tagging (env, service, version) (PR #[31](https://github.com/yob/puma-plugin-statsd/pull/37))
+* Adds support for Datadog unified service tagging (env, service, version) (PR #[37](https://github.com/yob/puma-plugin-statsd/pull/37))
 
 ## 2.0.0 2021-07-27
 

--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -102,7 +102,7 @@ Puma::Plugin.create do
     @launcher = launcher
 
     @statsd = ::StatsdConnector.new
-    @launcher.events.debug "statsd: enabled (host: #{@statsd.host})"
+    @launcher.log_writer.debug "statsd: enabled (host: #{@statsd.host})"
 
     # Fetch global metric prefix from env variable
     @metric_prefix = ENV.fetch("STATSD_METRIC_PREFIX", nil)
@@ -188,7 +188,7 @@ Puma::Plugin.create do
 
     sleep 5
     loop do
-      @launcher.events.debug "statsd: notify statsd"
+      @launcher.log_writer.debug "statsd: notify statsd"
       begin
         stats = ::PumaStats.new(Puma.stats_hash)
         @statsd.send(metric_name: prefixed_metric_name("puma.workers"), value: stats.workers, type: :gauge, tags: tags)
@@ -200,7 +200,7 @@ Puma::Plugin.create do
         @statsd.send(metric_name: prefixed_metric_name("puma.max_threads"), value: stats.max_threads, type: :gauge, tags: tags)
         @statsd.send(metric_name: prefixed_metric_name("puma.requests_count"), value: stats.requests_count, type: :gauge, tags: tags)
       rescue StandardError => e
-        @launcher.events.unknown_error e, nil, "! statsd: notify stats failed"
+        @launcher.log_writer.unknown_error e, nil, "! statsd: notify stats failed"
       ensure
         sleep 2
       end

--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -1,4 +1,5 @@
-# coding: utf-8, frozen_string_literal: true
+# coding: utf-8
+# frozen_string_literal: true
 require "puma"
 require "puma/plugin"
 require 'socket'
@@ -6,7 +7,7 @@ require 'socket'
 class StatsdConnector
   ENV_NAME = "STATSD_HOST"
   STATSD_TYPES = { count: 'c', gauge: 'g' }
-  METRIC_DELIMETER = ".".freeze
+  METRIC_DELIMETER = "."
 
   attr_reader :host, :port
 

--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -100,9 +100,15 @@ Puma::Plugin.create do
   # We can start doing something when we have a launcher:
   def start(launcher)
     @launcher = launcher
+    @log_writer =
+      if Gem::Version.new(Puma::Const::PUMA_VERSION) >= Gem::Version.new(6)
+        @launcher.log_writer
+      else
+        @launcher.events
+      end
 
     @statsd = ::StatsdConnector.new
-    @launcher.log_writer.debug "statsd: enabled (host: #{@statsd.host})"
+    @log_writer.debug "statsd: enabled (host: #{@statsd.host})"
 
     # Fetch global metric prefix from env variable
     @metric_prefix = ENV.fetch("STATSD_METRIC_PREFIX", nil)
@@ -188,7 +194,7 @@ Puma::Plugin.create do
 
     sleep 5
     loop do
-      @launcher.log_writer.debug "statsd: notify statsd"
+      @log_writer.debug "statsd: notify statsd"
       begin
         stats = ::PumaStats.new(Puma.stats_hash)
         @statsd.send(metric_name: prefixed_metric_name("puma.workers"), value: stats.workers, type: :gauge, tags: tags)
@@ -200,7 +206,7 @@ Puma::Plugin.create do
         @statsd.send(metric_name: prefixed_metric_name("puma.max_threads"), value: stats.max_threads, type: :gauge, tags: tags)
         @statsd.send(metric_name: prefixed_metric_name("puma.requests_count"), value: stats.requests_count, type: :gauge, tags: tags)
       rescue StandardError => e
-        @launcher.log_writer.unknown_error e, nil, "! statsd: notify stats failed"
+        @log_writer.unknown_error e, nil, "! statsd: notify stats failed"
       ensure
         sleep 2
       end

--- a/lib/puma/plugin/statsd.rb
+++ b/lib/puma/plugin/statsd.rb
@@ -163,6 +163,14 @@ Puma::Plugin.create do
       tags << "version:#{ENV["DD_VERSION"]}"
     end
 
+    # Support the origin detection over UDP from Datadog, it allows DogStatsD
+    # to detect where the container metrics come from, and tag metrics automatically.
+    #
+    # https://docs.datadoghq.com/developers/dogstatsd/?tab=kubernetes#origin-detection-over-udp
+    if ENV.has_key?("DD_ENTITY_ID")
+      tags << "dd.internal.entity_id:#{ENV["DD_ENTITY_ID"]}"
+    end
+
     # Return nil if we have no environment variable tags. This way we don't
     # send an unnecessary '|' on the end of each stat
     return nil if tags.empty?

--- a/puma-plugin-statsd.gemspec
+++ b/puma-plugin-statsd.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*.rb", "README.md", "CHANGELOG.md", "MIT-LICENSE"]
   spec.executables = ["statsd-to-stdout"]
 
-  spec.add_runtime_dependency "puma", ">= 5.0", "< 6"
+  spec.add_runtime_dependency "puma", ">= 6.0", "< 7"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/puma-plugin-statsd.gemspec
+++ b/puma-plugin-statsd.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name     = "puma-plugin-statsd"
-  spec.version  = "2.2.0"
+  spec.version  = "2.3.0"
   spec.author   = "James Healy"
   spec.email    = "james@yob.id.au"
 

--- a/puma-plugin-statsd.gemspec
+++ b/puma-plugin-statsd.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*.rb", "README.md", "CHANGELOG.md", "MIT-LICENSE"]
   spec.executables = ["statsd-to-stdout"]
 
-  spec.add_runtime_dependency "puma", ">= 6.0", "< 7"
+  spec.add_runtime_dependency "puma", ">= 5.0", "< 7"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/puma-plugin-statsd.gemspec
+++ b/puma-plugin-statsd.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name     = "puma-plugin-statsd"
-  spec.version  = "2.3.0"
+  spec.version  = "2.4.0"
   spec.author   = "James Healy"
   spec.email    = "james@yob.id.au"
 

--- a/puma-plugin-statsd.gemspec
+++ b/puma-plugin-statsd.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name     = "puma-plugin-statsd"
-  spec.version  = "2.1.0"
+  spec.version  = "2.2.0"
   spec.author   = "James Healy"
   spec.email    = "james@yob.id.au"
 


### PR DESCRIPTION
Update in the scope of https://fairmoney.atlassian.net/browse/FC-15539. 
Puma was upgraded in Monolith: https://github.com/fairmoney/monolith/pull/11698, so we need to update this gem too.